### PR TITLE
Clarify metric names in task documentation

### DIFF
--- a/tasks/stream-compression/index.md
+++ b/tasks/stream-compression/index.md
@@ -14,8 +14,8 @@ In this task, the time taken to serialize and deserialize the data is not consid
 
 ### Metrics
 
-- The primary metric is the serialized representation size of the RDF data, in bytes.
-- Additionally, the compression ratio can be calculated as the ratio of the reference size to the compressed size. The reference size is the size of the same data serialized using a baseline method, e.g., the N-Triples serialization format.
+- **Serialized representation size** – the primary metric, size of the serialized RDF data, in bytes.
+- **Compression ratio** – additionally, the compression ratio can be calculated as the ratio of the reference size to the compressed size. The reference size is the size of the same data serialized using a baseline method, e.g., the N-Triples serialization format.
     - In the RDF literature, the "compression ratio" is often defined as the inverse of the above definition and expressed as a percentage. For example, a compression ratio of (50%) means that the compressed data is half the size of the reference data.
 
 ## Results

--- a/tasks/stream-deserialization-throughput/index.md
+++ b/tasks/stream-deserialization-throughput/index.md
@@ -17,8 +17,8 @@ The task consists of deserializing RDF data stored in a byte stream to memory in
 
 ### Metrics
 
-- Throughput of the deserialization process, measured in RDF statements (triples or quads) per second. This is calculated as the total number of RDF statements deserialized divided by the total time taken to deserialize them.
-- Additionally, the throughput may be measured in terms of stream elements (RDF graphs or RDF datasets) per second.
+- **Deserialization throughput (in statements)** – throughput of the deserialization process, measured in RDF statements (triples or quads) per second. This is calculated as the total number of RDF statements deserialized divided by the total time taken to deserialize them.
+- **Deserialization throughput (in elements)** – additionally, the throughput may be measured in terms of stream elements (RDF graphs or RDF datasets) per second.
 
 ## Results
 

--- a/tasks/stream-latency-end-to-end/index.md
+++ b/tasks/stream-latency-end-to-end/index.md
@@ -37,7 +37,7 @@ To isolate the performance of the streaming process itself, the following steps 
 
 ### Metrics
 
-- Latency of streaming a stream element, measured typically in milliseconds. The measurement starts when the producer begins serializing the element and ends when the consumer finishes deserializing it.
+- **Stream element latency** – latency of streaming a stream element, measured typically in milliseconds. The measurement starts when the producer begins serializing the element and ends when the consumer finishes deserializing it.
 
 ## Results
 

--- a/tasks/stream-serialization-throughput/index.md
+++ b/tasks/stream-serialization-throughput/index.md
@@ -18,8 +18,8 @@ The task consists of serializing RDF data stored in memory in a grouped form (th
 
 ### Metrics
 
-- Throughput of the serialization process, measured in RDF statements (triples or quads) per second. This is calculated as the total number of RDF statements serialized divided by the total time taken to serialize them.
-- Additionally, the throughput may be measured in terms of stream elements (RDF graphs or RDF datasets) per second.
+- **Serialization throughput (in statements)** – throughput of the serialization process, measured in RDF statements (triples or quads) per second. This is calculated as the total number of RDF statements serialized divided by the total time taken to serialize them.
+- **Serialization throughput (in elements)** – additionally, the throughput may be measured in terms of stream elements (RDF graphs or RDF datasets) per second.
 
 ## Results
 

--- a/tasks/stream-throughput-end-to-end/index.md
+++ b/tasks/stream-throughput-end-to-end/index.md
@@ -27,8 +27,8 @@ To isolate the performance of the streaming process itself, the following steps 
 
 ### Metrics
 
-- Throughput of the streaming process, measured in RDF statements (triples or quads) per second. This is calculated as the total number of RDF statements streamed divided by the total time taken to serialize, transmit, and deserialized them.
-- Additionally, the throughput may be measured in terms of stream elements (RDF graphs or RDF datasets) per second.
+- **Streaming throughput (in statements)** – throughput of the streaming process, measured in RDF statements (triples or quads) per second. This is calculated as the total number of RDF statements streamed divided by the total time taken to serialize, transmit, and deserialized them.
+- **Streaming throughput (in elements)** – additionally, the throughput may be measured in terms of stream elements (RDF graphs or RDF datasets) per second.
 
 ## Results
 


### PR DESCRIPTION
This is to match the convenient style of metric names used in the flat category.